### PR TITLE
fix: add termination of unused workers

### DIFF
--- a/projects/workers/src/worker/pipes/worker.pipe.spec.ts
+++ b/projects/workers/src/worker/pipes/worker.pipe.spec.ts
@@ -32,4 +32,18 @@ describe('WorkerPipe', () => {
 
         expect(worker).not.toEqual(differentWorker);
     });
+
+    it('should terminate a previous worker', async () => {
+        const worker = await pipe.transform('a', (data: unknown) => data);
+
+        await pipe.transform('a', (data: unknown) => data);
+        await expectAsync(worker.toPromise()).toBeResolved();
+    });
+
+    it('should terminate a worker then a pipe is destroyed', async () => {
+        const worker = await pipe.transform('a', (data: unknown) => data);
+
+        pipe.ngOnDestroy();
+        await expectAsync(worker.toPromise()).toBeResolved();
+    });
 });

--- a/projects/workers/src/worker/pipes/worker.pipe.ts
+++ b/projects/workers/src/worker/pipes/worker.pipe.ts
@@ -14,7 +14,7 @@ export class WorkerPipe implements PipeTransform, OnDestroy {
 
     transform<T, R>(value: T, fn: WorkerFunction<T, R>): Observable<R> {
         if (this.fn !== fn) {
-            this.terminate();
+            this.terminateWorker();
             this.initNewWorker(fn);
         }
 
@@ -24,10 +24,10 @@ export class WorkerPipe implements PipeTransform, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        this.terminate();
+        this.terminateWorker();
     }
 
-    private terminate() {
+    private terminateWorker() {
         if (this.worker) {
             this.worker.terminate();
         }

--- a/projects/workers/src/worker/pipes/worker.pipe.ts
+++ b/projects/workers/src/worker/pipes/worker.pipe.ts
@@ -1,4 +1,4 @@
-import {Pipe, PipeTransform} from '@angular/core';
+import {OnDestroy, Pipe, PipeTransform} from '@angular/core';
 import {Observable} from 'rxjs';
 import {WebWorker} from '../classes/web-worker';
 import {toData} from '../operators/to-data';
@@ -7,21 +7,35 @@ import {WorkerFunction} from '../types/worker-function';
 @Pipe({
     name: 'waWorker',
 })
-export class WorkerPipe implements PipeTransform {
-    private workers = new WeakMap<WorkerFunction, WebWorker>();
-    private observers = new WeakMap<WebWorker, Observable<any>>();
+export class WorkerPipe implements PipeTransform, OnDestroy {
+    private fn!: WorkerFunction;
+    private worker!: WebWorker;
+    private observer!: Observable<any>;
 
     transform<T, R>(value: T, fn: WorkerFunction<T, R>): Observable<R> {
-        const worker: WebWorker<T, R> =
-            this.workers.get(fn) || WebWorker.fromFunction(fn);
+        if (this.fn !== fn) {
+            this.terminate();
+            this.initNewWorker(fn);
 
-        this.workers.set(fn, worker);
-        worker.postMessage(value);
+            this.worker.postMessage(value);
+        }
 
-        const observer = this.observers.get(worker) || worker.pipe(toData());
+        return this.observer;
+    }
 
-        this.observers.set(worker, observer);
+    ngOnDestroy(): void {
+        this.terminate();
+    }
 
-        return observer;
+    private terminate() {
+        if (this.worker) {
+            this.worker.terminate();
+        }
+    }
+
+    private initNewWorker<T, R>(fn: WorkerFunction<T, R>) {
+        this.fn = fn;
+        this.worker = WebWorker.fromFunction(fn);
+        this.observer = this.worker.pipe(toData());
     }
 }

--- a/projects/workers/src/worker/pipes/worker.pipe.ts
+++ b/projects/workers/src/worker/pipes/worker.pipe.ts
@@ -16,9 +16,9 @@ export class WorkerPipe implements PipeTransform, OnDestroy {
         if (this.fn !== fn) {
             this.terminate();
             this.initNewWorker(fn);
-
-            this.worker.postMessage(value);
         }
+
+        this.worker.postMessage(value);
 
         return this.observer;
     }


### PR DESCRIPTION
If pipe is destroyed a worker will be terminated

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the pipe is destroyed a worker will not be terminated.

Issue Number: N/A

## What is the new behavior?

If the pipe is destroyed a worker will be terminated.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No